### PR TITLE
Correctly map postgresql charsets to python charsets

### DIFF
--- a/postgresql_proxy/interceptors.py
+++ b/postgresql_proxy/interceptors.py
@@ -19,7 +19,10 @@ class Interceptor:
     @staticmethod
     def convert_encoding_to_python(encoding: str) -> str:
         encoding = encoding.lower()
-        return PG_PY_ENCODINGS.get(encoding, encoding)
+        result = PG_PY_ENCODINGS.get(encoding, encoding)
+        if not result:
+            raise Exception(f"Encoding {encoding} not supported by postgresql-proxy!")
+        return result
 
 
 class CommandInterceptor(Interceptor):

--- a/postgresql_proxy/interceptors.py
+++ b/postgresql_proxy/interceptors.py
@@ -1,4 +1,5 @@
 import logging
+from pg8000.converters import PG_PY_ENCODINGS
 
 class Interceptor:
     def __init__(self, interceptor_config, plugins, context):
@@ -12,8 +13,13 @@ class Interceptor:
     def get_codec(self):
         if self.context is not None and 'connect_params' in self.context:
             if self.context['connect_params'] is not None and 'client_encoding' in self.context['connect_params']:
-                return self.context['connect_params']['client_encoding']
+                return self.convert_encoding_to_python(self.context['connect_params']['client_encoding'])
         return 'utf-8'
+
+    @staticmethod
+    def convert_encoding_to_python(encoding: str) -> str:
+        encoding = encoding.lower()
+        return PG_PY_ENCODINGS.get(encoding, encoding)
 
 
 class CommandInterceptor(Interceptor):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+pg8000>=1.10
 psycopg2-binary>=2.7.5
 PyYAML>=3.13

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.0.3',
+        version='0.0.4',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,


### PR DESCRIPTION
Currently, some of the names for certain encodings differ between postgresql and python, but the current logic uses the client_encoding passed by the client as-is in python.

This PR fixes that, by using a mapping introduced in the pg8000 library (which is already a library in LocalStack, so easy to make use of it without adding a real additional dependency).

Postgresql charsets: https://www.postgresql.org/docs/current/multibyte.html
Python charsets: https://docs.python.org/3/library/codecs.html#standard-encodings