### PR TITLE
Fix connection management

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,19 @@ If you want to test it, do this. Otherwise scroll down for instructions on how t
   ```
   python proxy.py
   ```
+
+### Changelog
+
+- v0.1.0
+  - Fix connection management in #4  
+  Improve the connection management of the proxy, connections lifecycle, and improves CPU usage, fix migration done with Prisma
+- v0.0.5
+  - add support to modify and ignore incoming connection parameters in #2  
+    Fixes an issue with Redshift python connector using forbidden PostgreSQL connection parameters
+  - switch to using twine for package upload in #3
+- v0.0.4
+  - Correctly map postgresql charsets to python charsets in #1
+- v0.0.3
+  - add stop() method to proxy; refactor logging
+- v0.0.2
+  - fix socket file descriptors under Linux

--- a/postgresql_proxy/connection.py
+++ b/postgresql_proxy/connection.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Optional
 
 _logger = logging.getLogger("postgresql_proxy")
+
 
 class Connection:
     def __init__(self, sock, address, name, events, context):
@@ -10,7 +12,7 @@ class Connection:
         self.events = events
         self.context = context
         self.interceptor = None
-        self.redirect_conn = None
+        self.redirect_conn: Optional[Connection] = None
         self.out_bytes = b''
         self.in_bytes = b''
 

--- a/postgresql_proxy/interceptors.py
+++ b/postgresql_proxy/interceptors.py
@@ -34,24 +34,24 @@ class CommandInterceptor(Interceptor):
             ic_queries = self.interceptor_config.queries
             if packet_type == b'Q':
                 # Query, ends with b'\x00'
-                data = self.__intercept_query(data, ic_queries)
+                data = self._intercept_query(data, ic_queries)
             elif packet_type == b'P':
                 # Statement that needs parsing.
                 # First byte of the body is some Statement flag. Ignore, don't lose
                 # Next is the query, same as above, ends with an b'\x00'
                 # Last 2 bytes are the number of parameters. Ignore, don't lose
                 statement = data[0:1]
-                query = self.__intercept_query(data[1:-2], ic_queries)
+                query = self._intercept_query(data[1:-2], ic_queries)
                 params = data[-2:]
                 data = statement + query + params
             elif packet_type == b'':
                 # Connection request / context. Ignore the first 4 bytes, keep it
                 packet_start = data[0:4]
-                context_data = self.__intercept_context_data(data[4:-1])
+                context_data = self._intercept_context_data(data[4:-1])
                 data = packet_start + context_data
         return data
 
-    def __intercept_context_data(self, data):
+    def _intercept_context_data(self, data):
         # Each entry is terminated by b'\x00'
         entries = data.split(b'\x00')[:-1]
         entries = dict(zip(entries[0::2], entries[1::2]))
@@ -75,7 +75,7 @@ class CommandInterceptor(Interceptor):
         )
         return context_data + b'\x00\x00'
 
-    def __intercept_query(self, query, interceptors):
+    def _intercept_query(self, query, interceptors):
         logging.getLogger('intercept').debug("intercepting query\n%s", query)
         # Remove zero byte at the end
         query = query[:-1].decode('utf-8')

--- a/postgresql_proxy/proxy.py
+++ b/postgresql_proxy/proxy.py
@@ -27,22 +27,32 @@ interceptors.py - intercepting for modification
 import logging
 import selectors
 import socket
-import types
 from postgresql_proxy import connection, config_schema as cfg
 from postgresql_proxy.interceptors import ResponseInterceptor, CommandInterceptor
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger("postgresql_proxy")
+
+
+class SelectorKeyProxy(selectors.SelectorKey):
+    fileobj: socket.socket
+    data: connection.Connection
+    fd: int
+    events: int
 
 
 class Proxy(object):
-
-    def __init__(self, instance_config, plugins):
+    def __init__(self, instance_config, plugins, debug=False):
         self.plugins = plugins
         self.num_clients = 0
         self.instance_config = instance_config
         self.connections = []
         self.selector = selectors.DefaultSelector()
         self.running = True
+        self.sock = None
+        # this is used to track leftover sockets
+        self._debug = debug
+        if self._debug:
+            self._registered_conn = set()
 
     def __create_pg_connection(self, address, context):
         redirect_config = self.instance_config.redirect
@@ -51,50 +61,78 @@ class Proxy(object):
         pg_sock.connect((redirect_config.host, redirect_config.port))
         pg_sock.setblocking(False)
 
-        events = selectors.EVENT_READ | selectors.EVENT_WRITE
-
-        pg_conn = connection.Connection(pg_sock,
-                                        name    = redirect_config.name + '_' + str(self.num_clients),
-                                        address = address,
-                                        events  = events,
-                                        context = context)
+        events = selectors.EVENT_READ
+        redirect_config_name = redirect_config.name + '_' + str(self.num_clients)
+        pg_conn = connection.Connection(
+            pg_sock,
+            name=redirect_config_name,
+            address=address,
+            events=events,
+            context=context
+        )
 
         LOG.info("initiated client connection to %s:%s called %s",
-                 redirect_config.host, redirect_config.port, redirect_config.name)
+                 redirect_config.host, redirect_config.port, redirect_config_name)
         return pg_conn
 
-    def __register_conn(self, conn):
+    def __register_conn(self, conn: connection.Connection):
         try:
             self.selector.register(conn.sock, conn.events, data=conn)
         except Exception:
             # potentially already registered - this can happen if file descriptors
             # are reused for new sockets -> try to unregister/re-register
-            self.selector.unregister(conn.sock)
-            self.selector.register(conn.sock, conn.events, data=conn)
+            LOG.debug("exception while trying to register %s", conn.name)
+            self.selector.modify(conn.sock, conn.events, data=conn)
 
-    def __unregister_conn(self, conn):
+        if self._debug:
+            self._registered_conn.add(f"{conn.name}-{conn.sock.fileno()}")
+
+    def __unregister_conn(self, conn: connection.Connection):
+        LOG.debug("closing connection %s", conn.name)
         self.selector.unregister(conn.sock)
+        if conn.name.startswith("proxy"):
+            # send Terminate to PG to not leave it hanging waiting for query
+            # the client did not disconnect properly
+            # this will cause postgres to close the socket on its side cleanly
+            try:
+                LOG.debug("try closing connection %s", conn.redirect_conn.name)
+                conn.redirect_conn.sock.send(b'X\x00\x00\x00\x04')
+            except OSError:
+                LOG.debug("tried closing connection %s: already closed", conn.redirect_conn.name)
 
-    def accept_wrapper(self, sock):
+        if self._debug:
+            self._registered_conn.discard(f"{conn.name}-{conn.sock.fileno()}")
+
+    def accept_wrapper(self, sock: socket.socket):
+        """
+        This method is called whenever a new client connects to the proxy. It will create a connection to postgres and
+        proxy all data between both sockets. It will add a `Connection` object to the SelectorKey, to be able to
+        store state and share data between the sockets.
+        :param sock: the client socket
+        :return:
+        """
         clientsocket, address = sock.accept()  # Should be ready to
         clientsocket.setblocking(False)
-        self.num_clients+=1
+        self.num_clients += 1
         sock_name = '{}_{}'.format(self.instance_config.listen.name, self.num_clients)
         LOG.info("connection from %s, connection initiated %s", address, sock_name)
-
-        events = selectors.EVENT_READ | selectors.EVENT_WRITE
+        events = selectors.EVENT_READ
 
         # Context dictionary, for sharing state data, connection details, which might be useful for interceptors
         context = {
             'instance_config': self.instance_config
         }
 
-        conn = connection.Connection(clientsocket,
-                                     name    = sock_name,
-                                     address = address,
-                                     events  = events,
-                                     context = context)
+        # create a Connection object, representing the relation between a proxied client to postgres
+        conn = connection.Connection(
+            clientsocket,
+            name=sock_name,
+            address=address,
+            events=events,
+            context=context
+        )
 
+        # create the connection to Postgres
         pg_conn = self.__create_pg_connection(address, context)
 
         if self.instance_config.intercept is not None and self.instance_config.intercept.responses is not None:
@@ -105,10 +143,19 @@ class Proxy(object):
             conn.interceptor = CommandInterceptor(self.instance_config.intercept.commands, self.plugins, context)
             conn.redirect_conn = pg_conn
 
+        # Register both connections to be watched by the selector
         self.__register_conn(conn)
         self.__register_conn(pg_conn)
 
-    def service_connection(self, key, mask):
+    def service_connection(self, key: SelectorKeyProxy, mask):
+        """
+        This method proxies the messages between socket. It will use properties of the Connection object to
+        intercept and decode messages, modifies if needed, then send the message to the redirect_conn once it is
+        fully built.
+        :param key: SelectorKeyProxy, containing the socket and the Connection object
+        :param mask: mask of event, indicating what the socket is ready for
+        :return:
+        """
         sock = key.fileobj
         conn = key.data
         if mask & selectors.EVENT_READ:
@@ -118,17 +165,31 @@ class Proxy(object):
                 LOG.debug('%s received data:\n%s', conn.name, recv_data)
                 conn.received(recv_data)
             else:
-                LOG.info('%s connection closing %s', conn.name, conn.address)
+                LOG.debug('%s connection closing %s', conn.name, conn.address)
+                # A file object shall be unregistered prior to being closed.
+                self.__unregister_conn(conn)
                 sock.close()
-        if mask & selectors.EVENT_WRITE:
-            if conn.out_bytes:
-                LOG.debug('sending to %s:\n%s', conn.name, conn.out_bytes)
-                sent = sock.send(conn.out_bytes)  # Should be ready to write
-                conn.sent(sent)
 
-    def listen(self, max_connections = 8):
-        '''Listen server socket. On connect launch a new thread with the client connection as an argument
-        '''
+        next_conn = conn.redirect_conn
+        if next_conn.out_bytes:
+            try:
+                LOG.debug('sending to %s:\n%s', next_conn.name, next_conn.out_bytes)
+                sent = next_conn.sock.send(next_conn.out_bytes)  # Should be ready to write
+                next_conn.sent(sent)
+            except OSError:
+                # If one side is closed, close the other one
+                # this can happen in the case where the client disconnects, and postgres still return a response
+                # we then read the response then close the PG side of the socket.
+                LOG.debug('error sending to %s: connection closed', next_conn.name)
+                self.__unregister_conn(conn)
+                sock.close()
+
+    def listen(self, max_connections: int = 8):
+        """
+        Listen server socket. On connect, launch a selector polling for socket readiness to listen
+        :param max_connections:
+        :return:
+        """
         lconf = self.instance_config.listen
         ip, port = (lconf.host, lconf.port)
         try:
@@ -140,18 +201,38 @@ class Proxy(object):
             while self.running:
                 events = self.selector.select(timeout=1)
                 if not events:
+                    LOG.debug("polling selector...")
                     continue
-                hit = False
+
                 for key, mask in events:
-                    hit = True
+                    key: SelectorKeyProxy
                     if key.data is None:
+                        # if the data object has not been set, it means the socket has not yet been accepted
                         self.accept_wrapper(key.fileobj)
                     else:
+                        # manage the already proxied connections
                         self.service_connection(key, mask)
+
         except OSError as ex:
             LOG.error("Can't establish PostgreSQL proxy listener on port %s" % port, exc_info=ex)
         finally:
             LOG.info("Closing PostgreSQL proxy on port %s" % port)
+            self.selector.unregister(self.sock)
+            # this cleans up in case any connection was still opened
+            # it should not happen anymore
+            if self._debug:
+                LOG.debug("Registered connections dangling: %s", self._registered_conn)
+            registered_selector_sockets = [skey for i, skey in self.selector.get_map().items()]
+            for selector_key in registered_selector_sockets:
+                LOG.debug("Connection left: %s", selector_key)
+                selector_key: SelectorKeyProxy
+                try:
+                    self.selector.unregister(selector_key.fileobj)
+                    selector_key.fileobj.close()
+                except OSError:
+                    continue
+
+            self.selector.close()
             self.sock.close()
             self.sock = None
 
@@ -159,8 +240,10 @@ class Proxy(object):
         self.running = False
 
 
-if(__name__=='__main__'):
-    import importlib, yaml, os
+if __name__ == '__main__':
+    import importlib
+    import yaml
+    import os
 
     path = os.path.dirname(os.path.realpath(__file__))
     config = None

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.0.6',
+        version='0.1.0',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.0.5',
+        version='0.0.6',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,


### PR DESCRIPTION
This PR adds some quality of life changes to the proxy, as well as optimisations concerning selector polling (the selector would burn some CPU as it was polling on `EVENT_WRITE` which was always true. It would return every 1ms, now correctly wait for 1s timeout while selecting. The socket will manage if the redirected socket is writable, and if not, can always raise an error).

It adds different checks in the lifecycle on the connection, and properly terminate Postgres side with a `Termination` message as described by the PostgreSQL documentation (https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-TERMINATE) to follow the correct message flow. Sometimes the client would disconnected without sending it, which would let the Postgres side in a `ReadyForQuery` state, waiting to receive something which would never come. 

This came to light with this issue: https://github.com/prisma/prisma/issues/11134
After reproducing locally, it seems the issue is now solved.
