### PR TITLE
fix connection termination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,8 @@ venv.bak/
 # visual studio code settings
 .vscode
 
+# pycharm settings
+.idea
+
 # private config information
 config.yml

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you want to test it, do this. Otherwise scroll down for instructions on how t
 
 ### Changelog
 
+- v0.1.1
+  - Fix connection termination in [#5](https://github.com/localstack/postgresql-proxy/pull/5)
 - v0.1.0
   - Fix connection management in [#4](https://github.com/localstack/postgresql-proxy/pull/4)  
   Improve the connection management of the proxy, connections lifecycle, and improves CPU usage, fix migration done with Prisma

--- a/postgresql_proxy/proxy.py
+++ b/postgresql_proxy/proxy.py
@@ -90,7 +90,7 @@ class Proxy(object):
     def _unregister_conn(self, conn: connection.Connection):
         LOG.debug("closing connection %s", conn.name)
         self.selector.unregister(conn.sock)
-        if conn.name.startswith("proxy"):
+        if conn.name.startswith("proxy") and not conn.terminated:
             # send Terminate to PG to not leave it hanging waiting for query
             # the client did not disconnect properly
             # this will cause postgres to close the socket on its side cleanly

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.1.0',
+        version='0.1.1',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,


### PR DESCRIPTION
While testing the proxy for a bug report, it came to light that we would always try to send a termination packet to Postgres when the proxied client would close the connection, even if it already sent it before. We now set a property if the client already sent a termination message, and won't send it again. 