### PR TITLE
fix error in process_inbound_packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you want to test it, do this. Otherwise scroll down for instructions on how t
 
 ### Changelog
 
+- v0.1.2
+  - Fix error in process_inbound_packet [#6](https://github.com/localstack/postgresql-proxy/pull/6)
 - v0.1.1
   - Fix connection termination in [#5](https://github.com/localstack/postgresql-proxy/pull/5)
 - v0.1.0

--- a/postgresql_proxy/connection.py
+++ b/postgresql_proxy/connection.py
@@ -64,7 +64,10 @@ class Connection:
 
         message = header + body
         _logger.debug("Received message. Relaying. Speaker: %s, message:\n%s", self.name, message)
-        self.redirect_conn.out_bytes += message
+
+        if self.redirect_conn:
+            # redirect_conn might not be set (anymore) at this stage
+            self.redirect_conn.out_bytes += message
 
     def sent(self, num_bytes):
         self.out_bytes = self.out_bytes[num_bytes:]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.1.1',
+        version='0.1.2',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,


### PR DESCRIPTION
### Background
Recently, we got notified about a customer that the RDS instance was not reachable, with the logs in LocalStack:

```
postgresql_proxy           : PostgreSQL proxy quit unexpectedly:
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/postgresql_proxy/proxy.py", line 222, in listen
    self.service_connection(key, mask)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/postgresql_proxy/proxy.py", line 170, in service_connection
    conn.received(recv_data)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/postgresql_proxy/connection.py", line 51, in received
    self.process_inbound_packet(header, body)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/postgresql_proxy/connection.py", line 67, in process_inbound_packet
    self.redirect_conn.out_bytes += message
AttributeError: 'NoneType' object has no attribute 'out_bytes'
```

I was able to reproduce this issue locally, by running the following `psql` command for a RDS-instance created in LocalStack:
```
psql -d test -U test -p 4510 -h localhost
```
* As we need a password here to connect to the instance, the command should normally include the `-W` option. When this option is included, the password prompt is shown instantly, and the connection succeeds
* If the `-W` option is omitted, the `psql` still shows (a slightly different) password prompt, but before we can see some messages being send to the proxy:
   ``` 
   ----> Received message. Relaying. Speaker: proxy_2, message:
   b'\x00\x00\x00\n\x04\xd2\x16/\x00\x00'
   ----> Received message. Relaying. Speaker: postgresql_2, message:
   b'N'
   ----> Received message. Relaying. Speaker: proxy_2, message:
   b'\x00\x00\x00L\x00\x03\x00\x00client_encoding\x00UTF8\x00user\x00test\x00database\x00test\x00application_name\x00psql\x00\x00'
   ----> Received message. Relaying. Speaker: postgresql_2, message:
   b'R\x00\x00\x00\x08\x00\x00\x00\x03'
   ----> resetting connection proxy_2
   ----> Received message. Relaying. Speaker: postgresql_2, message:
   b'E\x00\x00\x00nSFATAL\x00VFATAL\x00C08P01\x00Mexpected password response, got message type 88\x00Fauth.c\x00L671\x00Rrecv_password_packet\x00\x00'
   ---> error, redirect_conn is not set
   ```
    * the last line is where the `self.redirect_conn` is None, and the connection to the proxy is broken with the error message from above. Somewhere in between the connection seems to be [reset here](https://github.com/localstack/postgresql-proxy/blob/master/postgresql_proxy/proxy.py#L101).


### Solution
In order to not terminate the proxy, we need a check in the `process_inbound_packet` that ensures the `self.redirect_conn` is still available.