### PR TITLE
add support for ParameterStatus response interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you want to test it, do this. Otherwise scroll down for instructions on how t
 
 ### Changelog
 
+- v0.2.0
+  - Add support for intercepting [ParameterStatus](https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-PARAMETERSTATUS) responses from Postgres [#7](https://github.com/localstack/postgresql-proxy/pull/7)
 - v0.1.2
   - Fix error in process_inbound_packet [#6](https://github.com/localstack/postgresql-proxy/pull/6)
 - v0.1.1

--- a/postgresql_proxy/config_schema.py
+++ b/postgresql_proxy/config_schema.py
@@ -3,9 +3,6 @@ import logging
 ''' This class is used to validate the config
 '''
 class Schema:
-    def __init__(self):
-        pass
-
     def _validate(self):
         pass
 
@@ -66,6 +63,17 @@ class InterceptCommandSettings(Schema):
         })
 
 
+class InterceptResponseSettings(Schema):
+    def __init__(self, data):
+        self.parameter_responses = []
+        self.connects = None
+
+        self._populate(data, {
+            'parameter_status': [InterceptQuerySettings],
+            'connects': str
+        })
+
+
 class InterceptSettings(Schema):
     def __init__(self, data):
         self.commands = None
@@ -73,7 +81,7 @@ class InterceptSettings(Schema):
 
         self._populate(data, {
             'commands': InterceptCommandSettings,
-            'responses': str
+            'responses': InterceptResponseSettings,
         })
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.1.2',
+        version='0.2.0',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,


### PR DESCRIPTION
Add support for response interceptors, needed for upgrading flake8 and black via a transitive dependency to packaging>22.
This allows an interceptor in the shape of the following:
```python
class ResponseParameterStatusInterceptor:
    def rewrite_parameter(key: str, value: str, context: dict=None) -> tuple[str, str]: ...
```

To intercept and modify the key and value of the ParameterStatus (see https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-PARAMETERSTATUS).

This is because Postgres would return the following for the server version:
```
b'S' b'application_name\x00_pytest.python\x00'
b'S' b'client_encoding\x00UTF8\x00'
b'S' b'DateStyle\x00ISO, MDY\x00'
b'S' b'integer_datetimes\x00on\x00'
b'S' b'IntervalStyle\x00postgres\x00'
b'S' b'is_superuser\x00on\x00'
b'S' b'server_encoding\x00UTF8\x00'
b'S' b'server_version\x0011.21 (Debian 11.21-1.pgdg110+1)\x00'
b'S' b'session_authorization\x00test1\x00'
b'S' b'standard_conforming_strings\x00on\x00'
b'S' b'TimeZone\x00Etc/UTC\x00'
```

As we can see, the server_version `11.21 (Debian 11.21-1.pgdg110+1)` is quite complicated, and the `redshift_connector` expect a version to be strict semantic versioning (using `packaging`>22), and will fail while trying to parse this.

We will add an interceptor modifying the `server_version` to be `11.21` only. 

\cc @alexrashed 