### PR TITLE
fix partial send of outbound data

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you want to test it, do this. Otherwise scroll down for instructions on how t
 
 ### Changelog
 
+- v0.2.1
+  - Fix partial send of outbound packets [#8](https://github.com/localstack/postgresql-proxy/pull/8)
 - v0.2.0
   - Add support for intercepting [ParameterStatus](https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-PARAMETERSTATUS) responses from Postgres [#7](https://github.com/localstack/postgresql-proxy/pull/7)
 - v0.1.2

--- a/postgresql_proxy/proxy.py
+++ b/postgresql_proxy/proxy.py
@@ -181,9 +181,10 @@ class Proxy(object):
         next_conn = conn.redirect_conn
         if next_conn and next_conn.out_bytes:
             try:
-                LOG.debug('sending to %s:\n%s', next_conn.name, next_conn.out_bytes)
-                sent = next_conn.sock.send(next_conn.out_bytes)
-                next_conn.sent(sent)
+                while next_conn.out_bytes:
+                    LOG.debug('sending to %s:\n%s', next_conn.name, next_conn.out_bytes)
+                    sent = next_conn.sock.send(next_conn.out_bytes)
+                    next_conn.sent(sent)
             except OSError:
                 # If one side is closed, close the other one
                 # this can happen in the case where the client disconnects, and postgres still return a response

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.2.0',
+        version='0.2.1',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,


### PR DESCRIPTION
We got a report from a customer that running a migration with [diesel](http://diesel.rs) would hang.

After investigating, it seems running an insert query of approximately 25MiB would just hang.

I've tracked down the reason for it: the flow of our proxy is flawed. Basically, we wait on the "receiving" socket, in this migration case, the client, so that it sends data. We then construct our packet, and once this packet is complete, we intercept it and populate the "outbound" packet to be sent to the server (the packet sent by the client and intercepted). 
However, we only call `Socket.send` once there, and do the right thing by slicing the `outbound` data with what we really sent. However, to get to send again, we need the client to send more data. But the client is waiting for the server to respond, and the server hasn't received anything (or just a partial send, not a full query). 

Until we refactor the proxy deeper, the fix consist of iterating over the outbound data until there's none left. I've tested it locally and it solved the issue. 

As an alternative solution, using `Socket.sendall` could also work, and we should then remove the whole logic around slicing the `outbound` data with the `sent` length. 