### PR TITLE
fix(postgresql-proxy): prevent SSL COPY stalls by draining pending SSL buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ If you want to test it, do this. Otherwise scroll down for instructions on how t
   ```
 
 ### Changelog
+- v0.3.1
+  - Fix SSL COPY stalls by draining pending SSL buffer after recv [#11](https://github.com/localstack/postgresql-proxy/pull/11)
+  - Fix intermittent `BlockingIOError` on macOS during SSL negotiation
 - v0.3.0
   - Add support for SSL connections [#9](https://github.com/localstack/postgresql-proxy/pull/9)
 - v0.2.1

--- a/postgresql_proxy/proxy.py
+++ b/postgresql_proxy/proxy.py
@@ -130,6 +130,9 @@ class Proxy(object):
 
         # Accept the raw connection
         clientsocket, address = sock.accept()
+        # On macOS, accepted sockets inherit O_NONBLOCK from the listening socket.
+        # SSL negotiation uses blocking recv, so we must set blocking explicitly here.
+        clientsocket.setblocking(True)
 
         # Check if SSL is enabled for this proxy
         if self.ssl_context:
@@ -234,6 +237,15 @@ class Proxy(object):
                 if recv_data:
                     LOG.debug('%s received data:\n%s', conn.name, recv_data)
                     conn.received(recv_data)
+                    # excerpt from https://docs.python.org/3/library/ssl.html#ssl-nonblocking
+                    # Conversely, since the SSL layer has its own framing, a SSL socket may still have data available
+                    # for reading without select() being aware of it. Therefore, you should first call SSLSocket.recv()
+                    # to drain any potentially available data, and then only block on a select() call if still necessary.
+                    while isinstance(sock, ssl.SSLSocket) and sock.pending() > 0:
+                        extra = sock.recv(4096)
+                        if extra:
+                            LOG.debug('%s received pending SSL data:\n%s', conn.name, extra)
+                            conn.received(extra)
                 else:
                     self._unregister_conn(conn)
                     LOG.debug('%s connection closing %s', conn.name, conn.address)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.3.0',
+        version='0.3.1',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,


### PR DESCRIPTION
## Motivation

Fixes `UNC-472`: Postgres proxy could hang for `sslmode=require` sessions running large `psql -f` / COPY-heavy workloads.

## Root cause

`selector.select()` operates at the TCP layer and is unaware of data already decrypted and buffered inside the SSL layer. After an initial `recv()`, buffered SSL bytes would not be seen by the next `select()` call, stalling large transfers.

## Changes (`postgresql_proxy/proxy.py`)

- After each `recv()` in `service_connection()`, drain any remaining SSL-buffered bytes using `sock.pending()` (per [Python SSL non-blocking docs](https://docs.python.org/3/library/ssl.html#ssl-nonblocking)).
- Add explicit `setblocking(True)` on accepted sockets before SSL negotiation. On macOS/BSD, accepted sockets inherit `O_NONBLOCK` from the listening socket (unlike Linux), causing intermittent `BlockingIOError` on the `MSG_PEEK` recv ~1/10 times during SSL startup.

## Expected impact

Prevents SSL COPY-session stalls for large dump-like workloads without changing the proxy's overall non-blocking architecture.