### PR TITLE
feat(ci): add GitHub Actions workflow and act support

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+-P ubuntu-24.04=catthehacker/ubuntu:act-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,54 @@
+name: Run Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      E2E_PG_HOST: 127.0.0.1
+      E2E_PG_PORT: 5432
+      E2E_PG_USER: postgres
+      E2E_PG_PASSWORD: postgres
+      E2E_PG_DB: postgres
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-timeout
+
+      - name: Run tests
+        run: |
+          python -m pytest -vv
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,15 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
           - 5432:5432
+        # The official postgres image does not expose a default Docker HEALTHCHECK,
+        # so we define one explicitly for the GitHub Actions service container.
         options: >-
           --health-cmd "pg_isready -U postgres"
           --health-interval 10s
@@ -44,11 +46,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y postgresql-client
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-timeout
+          make install-test
 
       - name: Run tests
         run: |
-          python -m pytest -vv
-
+          make test

--- a/Makefile
+++ b/Makefile
@@ -78,4 +78,13 @@ start-pg-and-test: ## Start local PostgreSQL container, run all tests, and clean
 	$(MAKE) stop-postgres; \
 	exit $$status
 
-.PHONY: usage install install-test install-lint clean publish lint start-postgres stop-postgres test start-pg-and-test
+ACT_CMD ?= act
+ACT_WORKFLOW ?= .github/workflows/tests.yml
+ACT_JOB ?= tests
+ACT_PULL ?= false
+ACT_CONTAINER_ARCH ?= linux/arm64
+
+test-act:          ## Run the CI test workflow locally with act
+	$(ACT_CMD) -W $(ACT_WORKFLOW) -j $(ACT_JOB) --pull=$(ACT_PULL) --container-architecture $(ACT_CONTAINER_ARCH)
+
+.PHONY: usage install install-test install-lint clean publish lint start-postgres stop-postgres test test-act start-pg-and-test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TEST_REQS ?= requirements-test.txt
 LINT_REQS ?= requirements-lint.txt
 
 PG_TEST_CONTAINER ?= pg-proxy-local-tests
-PG_TEST_IMAGE ?= postgres:16
+PG_TEST_IMAGE ?= postgres:18
 PG_TEST_PORT ?= 55432
 PG_TEST_USER ?= postgres
 PG_TEST_PASSWORD ?= postgres
@@ -17,7 +17,7 @@ usage:             ## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 
 install:           ## Install dependencies in local virtualenv folder
-	(test `which virtualenv` || $(PIP_CMD) install --user virtualenv) && \
+	(test `which virtualenv` || $(PIP_CMD) install virtualenv) && \
 		(test -e $(VENV_DIR) || virtualenv $(VENV_OPTS) $(VENV_DIR)) && \
 		($(VENV_RUN) && $(PIP_CMD) install --upgrade pip) && \
 		(test ! -e requirements.txt || ($(VENV_RUN); $(PIP_CMD) install -r requirements.txt))

--- a/README.md
+++ b/README.md
@@ -149,3 +149,27 @@ python -m pytest tests/test_plugins.py -vv
 ```
 
 If PostgreSQL is not reachable, tests fail fast at startup.
+
+#### 3) Run CI locally with `act`
+
+Run the GitHub Actions test workflow locally with [`act`](https://github.com/nektos/act):
+
+On macOS, install `act` with Homebrew:
+
+```bash
+brew install act
+```
+
+```bash
+make test-act
+```
+
+Useful overrides for local runs:
+
+```bash
+# Refresh images explicitly when needed
+make test-act ACT_PULL=true
+
+# Match GitHub runner architecture on Apple Silicon (slower)
+make test-act ACT_CONTAINER_ARCH=linux/amd64
+```


### PR DESCRIPTION
Stacked on #13.

This PR adds a GitHub Actions CI workflow that runs the full test suite on Python 3.13, along with `act` support for running the same workflow locally.

## Changes

- Add `.github/workflows/tests.yml`: runs the full test suite on Python 3.13 via GitHub Actions
- Add `.actrc`: default flags for running the workflow locally with `act`
- Add `Makefile` target: `test-act` (runs the CI workflow locally via `act`)
- Extend root `README.md` testing section with `act` instructions

