### PR TITLE
fix(proxy): reduce SSL connection overhead by setting TCP_NODELAY

### DIFF
--- a/postgresql_proxy/proxy.py
+++ b/postgresql_proxy/proxy.py
@@ -71,6 +71,7 @@ class Proxy(object):
         redirect_config = self.instance_config.redirect
 
         pg_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        pg_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         pg_sock.connect((redirect_config.host, redirect_config.port))
         pg_sock.setblocking(False)
 
@@ -130,6 +131,7 @@ class Proxy(object):
 
         # Accept the raw connection
         clientsocket, address = sock.accept()
+        clientsocket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         # On macOS, accepted sockets inherit O_NONBLOCK from the listening socket.
         # SSL negotiation uses blocking recv, so we must set blocking explicitly here.
         clientsocket.setblocking(True)


### PR DESCRIPTION
## Summary

- Set `TCP_NODELAY` on both the client-facing socket and the proxy-to-PostgreSQL socket
- Disables Nagle's algorithm, which was buffering small packets for up to 40ms waiting to batch them — the opposite of what a request/response protocol needs

## Background

SSL connections through the proxy showed ~3x latency overhead compared to no-SSL for workloads that open many short-lived connections (the customer-reported pattern). Root cause analysis showed the overhead was entirely in connection setup, not per-query processing (a single reused connection had no measurable difference between SSL and no-SSL).

PostgreSQL connection startup is a rapid exchange of small messages (auth, parameter status, ready-for-query). With SSL there are even more round trips (SSLRequest → "S" → TLS handshake → startup). Nagle's algorithm was delaying each of these small packets, compounding the latency.

`TCP_NODELAY` is the standard setting for interactive protocol proxies. `libpq` and JDBC both set it unconditionally.

## Results

Measured with 101 connections × 3 queries each:

| | no-SSL | SSL | Delta |
|---|---|---|---|
| Before | 3s | 9s | +6s |
| After | 3s | 5s | +2s |


## Related readings

https://en.wikipedia.org/wiki/Nagle%27s_algorithm
https://brooker.co.za/blog/2024/05/09/nagle.html