### PR TITLE
fix(proxy): add backpressure handling to prevent hang on large responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Or run it without activating the venv:
 ```
 
 ## Changelog
+- v0.3.2
+  - Fix proxy hang on large responses by adding backpressure handling [#16](https://github.com/localstack/postgresql-proxy/pull/16)
+  - Reduce SSL connection overhead by setting `TCP_NODELAY` [#15](https://github.com/localstack/postgresql-proxy/pull/15)
 - v0.3.1
   - Fix SSL COPY stalls by draining pending SSL buffer after recv [#11](https://github.com/localstack/postgresql-proxy/pull/11)
   - Fix intermittent `BlockingIOError` on macOS during SSL negotiation

--- a/postgresql_proxy/proxy.py
+++ b/postgresql_proxy/proxy.py
@@ -253,10 +253,29 @@ class Proxy(object):
                     LOG.debug('%s connection closing %s', conn.name, conn.address)
                     # A file object shall be unregistered prior to being closed.
                     sock.close()
+                    return
             except OSError as e:
                 # it means the socket was closed by peer
                 LOG.debug('%s connection closed by peer %s: %s', conn.name, conn.address, e)
                 self._unregister_conn(conn)
+                return
+
+        if mask & selectors.EVENT_WRITE:
+            # Socket has buffer space — flush this connection's backlogged output.
+            try:
+                while conn.out_bytes:
+                    sent = sock.send(conn.out_bytes)
+                    conn.sent(sent)
+                # All data drained; stop watching for writability.
+                conn.events = selectors.EVENT_READ
+                self.selector.modify(sock, selectors.EVENT_READ, data=conn)
+            except BlockingIOError:
+                pass  # Still full; will retry on the next EVENT_WRITE notification.
+            except OSError as e:
+                LOG.debug('%s closed while flushing backlog: %s', conn.name, e)
+                self._unregister_conn(conn)
+                sock.close()
+                return
 
         next_conn = conn.redirect_conn
         if next_conn and next_conn.out_bytes:
@@ -265,6 +284,15 @@ class Proxy(object):
                     LOG.debug('sending to %s:\n%s', next_conn.name, next_conn.out_bytes)
                     sent = next_conn.sock.send(next_conn.out_bytes)
                     next_conn.sent(sent)
+                # All sent; clear write interest if it was previously registered.
+                if next_conn.events & selectors.EVENT_WRITE:
+                    next_conn.events = selectors.EVENT_READ
+                    self.selector.modify(next_conn.sock, selectors.EVENT_READ, data=next_conn)
+            except BlockingIOError:
+                # next_conn's send buffer is full — register for writability so we retry when there's space.
+                if not (next_conn.events & selectors.EVENT_WRITE):
+                    next_conn.events = selectors.EVENT_READ | selectors.EVENT_WRITE
+                    self.selector.modify(next_conn.sock, next_conn.events, data=next_conn)
             except OSError:
                 # If one side is closed, close the other one
                 # this can happen in the case where the client disconnects, and postgres still return a response

--- a/postgresql_proxy/proxy.py
+++ b/postgresql_proxy/proxy.py
@@ -269,7 +269,7 @@ class Proxy(object):
                 # All data drained; stop watching for writability.
                 conn.events = selectors.EVENT_READ
                 self.selector.modify(sock, selectors.EVENT_READ, data=conn)
-            except BlockingIOError:
+            except (BlockingIOError, ssl.SSLWantWriteError):
                 pass  # Still full; will retry on the next EVENT_WRITE notification.
             except OSError as e:
                 LOG.debug('%s closed while flushing backlog: %s', conn.name, e)
@@ -288,7 +288,7 @@ class Proxy(object):
                 if next_conn.events & selectors.EVENT_WRITE:
                     next_conn.events = selectors.EVENT_READ
                     self.selector.modify(next_conn.sock, selectors.EVENT_READ, data=next_conn)
-            except BlockingIOError:
+            except (BlockingIOError, ssl.SSLWantWriteError):
                 # next_conn's send buffer is full — register for writability so we retry when there's space.
                 if not (next_conn.events & selectors.EVENT_WRITE):
                     next_conn.events = selectors.EVENT_READ | selectors.EVENT_WRITE

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if __name__ == '__main__':
 
     setup(
         name='postgresql-proxy',
-        version='0.3.1',
+        version='0.3.2',
         description='Postgresql Proxy',
         packages=find_packages(exclude=('tests', 'tests.*')),
         install_requires=install_requires,

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -227,6 +227,70 @@ def test_repeated_connect_query_smoke_no_hang(postgres_settings, plain_proxy_por
 
 
 @pytest.mark.timeout(60)
+@pytest.mark.parametrize("sslmode", ["disable", "require"])
+@pytest.mark.parametrize(
+    ["sql", "expected"],
+    [
+        pytest.param(
+            "SELECT 1",
+            [(1,)],
+            id="tiny-1B",
+        ),
+        pytest.param(
+            "SELECT repeat('x', 1024)",
+            [("x" * 1024,)],
+            id="small-1KB",
+        ),
+        pytest.param(
+            "SELECT repeat('x', 102400)",
+            [("x" * 102400,)],
+            id="medium-100KB",
+        ),
+        pytest.param(
+            "SELECT repeat('x', 1048576)",
+            [("x" * 1048576,)],
+            id="large-1MB",
+        ),
+        pytest.param(
+            "SELECT repeat('x', 10485760)",
+            [("x" * 10485760,)],
+            id="xlarge-10MB",
+        ),
+        pytest.param(
+            "SELECT i FROM generate_series(1, 10000) AS t(i)",
+            [(i,) for i in range(1, 10001)],
+            id="rows-10k",
+        ),
+        pytest.param(
+            "SELECT i FROM generate_series(1, 100000) AS t(i)",
+            [(i,) for i in range(1, 100001)],
+            id="rows-100k",
+        ),
+    ]
+)
+def test_various_payload_sizes(
+    postgres_settings,
+    plain_proxy_port,
+    ssl_proxy_port,
+    sslmode,
+    sql,
+    expected,
+):
+    with psycopg2.connect(
+        host="127.0.0.1",
+        port=plain_proxy_port if sslmode == "disable" else ssl_proxy_port,
+        user=postgres_settings["user"],
+        password=postgres_settings["password"],
+        dbname=postgres_settings["dbname"],
+        sslmode=sslmode,
+        connect_timeout=3,
+    ) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            assert cur.fetchall() == expected
+
+
+@pytest.mark.timeout(60)
 def test_psql_ssl_file_batch_stress_no_hang(postgres_settings, ssl_proxy_port):
     if shutil.which("psql") is None:
         pytest.fail("psql is required for this test but was not found in PATH")


### PR DESCRIPTION
## Summary

- When forwarding large responses, the proxy could deadlock: the receiver's TCP buffer fills up, which fills the proxy's send buffer, which stalls the sender via flow control. With no `EVENT_WRITE` handling the proxy had no way to retry the stalled send.
- `BlockingIOError` and `ssl.SSLWantWriteError` (both subclasses of `OSError`) were being swallowed by the generic connection-close handler, tearing down the connection instead of retrying. `SSLWantWriteError` is raised by non-blocking SSL sockets when the underlying TCP buffer is full — distinct from `BlockingIOError` on plain sockets.
- The deadlock is reliably triggered by responses larger than the TCP send buffer (confirmed at >400 KB on macOS localhost; threshold varies by OS and kernel tuning).

## Changes

**`proxy.py`**
- Catch `BlockingIOError` / `ssl.SSLWantWriteError` explicitly before `OSError` in both send paths; register `EVENT_WRITE` on the destination socket so the selector retries the flush when buffer space is available.
- Add an `EVENT_WRITE` handler on `conn` itself to drain any backlogged `out_bytes` after a previous partial-send stall.
- Add `return` guards after connection close in the `EVENT_READ` path to prevent fall-through into stale `redirect_conn` state (double-unregister / use-after-close).

**`tests/test_proxy.py`**
- Add `test_various_payload_sizes` parametrized over 1 B, 1 KB, 100 KB, 1 MB, 10 MB and 10 k / 100 k rows, run over both plain and SSL connections. Without the fix the 1 MB+ cases hang.

## Test plan

- [x] `pytest tests/test_proxy.py -k test_various_payload_sizes` — all 14 cases pass
- [x] `pytest tests/test_proxy.py` — existing tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)